### PR TITLE
healthcheck necessary for pull worker to verify uptime before grabbing tasks

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -7,6 +7,10 @@ model = load_model()
 
 app = Sanic("my_app")
 
+@app.route('/healthcheck', methods=["GET"])
+def healthcheck(request):
+    return response.json({"state": "healthy"})
+
 @app.route('/', methods=["POST"])
 def inference(request):
     try:


### PR DESCRIPTION
# Why
The banana serverless integration runs a task pull worker as a sidecar to the python http server users define here. Because the python http server will take some time to warm up (loading model to GPU, one time initialization work), we cannot have the task pull worker immediately start trying to funnel traffic to the http server. I've added a /healthcheck endpoint that the pull worker can poll to verify the system is ready. Users can configure this if they want something beyond a "healthy" message, such as test running the model with a payload.