### PR TITLE
gpg key rotation.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,10 @@ FROM pytorch/pytorch:1.8.1-cuda11.1-cudnn8-devel
 
 WORKDIR /
 
+# nvidia rotated their GPG keys so need to refresh them 
+RUN rm /etc/apt/sources.list.d/cuda.list
+RUN rm /etc/apt/sources.list.d/nvidia-ml.list
+
 # Install git
 RUN apt-get update && apt-get install -y git
 


### PR DESCRIPTION
nvidia force-updated their keys and this broke a bunch of repos including pytorch-cuda. fixing build by removing old gpg keys and forcing redownload at install-time