### PR TITLE
docs/made-model-variable-more-obvious

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,7 +2,7 @@ from transformers import pipeline
 import torch
 
 # Init is ran on server startup
-# Load your model to GPU as a global variable here.
+# Load your model to GPU as a global variable here using the variable name "model"
 def init():
     global model
     


### PR DESCRIPTION
# Why
We do some automagical work to reduce cold start, which grabs the global object called "model" from the init() function and modifies it for up to 10x faster boot.

Users frequently modify the init(), which is totally fine, but if the model is not named "model" then the users lose the fastboot optimizations.

I added this comment to make it more clear.