### PR TITLE
Fix/put sanic in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ RUN pip3 install -r requirements.txt
 
 # We add the banana boilerplate here
 ADD server.py .
+# And install banana dependencies
+RUN pip3 install sanic
 
 # Add your model weight files 
 # (in this case we have a python script)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+sanic
 transformers
 accelerate

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-sanic
 transformers
 accelerate


### PR DESCRIPTION
# Why
The sanic install in requirements.txt was confusing people because they'd delete it while modifying requirements for their own use. I added the install into the dockerfile as well as a redundancy. 