### PR TITLE
Change port to integer

### DIFF
--- a/server.py
+++ b/server.py
@@ -39,4 +39,4 @@ def inference(request):
 
 
 if __name__ == '__main__':
-    server.run(host='0.0.0.0', port="8000", workers=1)
+    server.run(host='0.0.0.0', port=8000, workers=1)


### PR DESCRIPTION

# What is this?
Sanic has a type check on the `port` argument to server.run() and will throw an Error if `port` is a string.  This commit fixes that.

# Why?
Using this template currently results in failed deployments. 

# How did you test to ensure no regressions?
N/A
# If this is a new feature what is one way you can make this break?
N/A