### PR TITLE
model id specified in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,9 @@ RUN pip3 install --upgrade pip
 ADD requirements.txt requirements.txt
 RUN pip3 install -r requirements.txt
 
+# Set model id as an ENV variable
+ENV MODEL_ID bert-base-uncased
+
 # We add the banana boilerplate here
 ADD server.py .
 

--- a/app.py
+++ b/app.py
@@ -1,13 +1,15 @@
 from transformers import pipeline
 import torch
+import os
 
 # Init is ran on server startup
 # Load your model to GPU as a global variable here using the variable name "model"
 def init():
     global model
+    model_id = os.getenv("MODEL_ID")
     
     device = 0 if torch.cuda.is_available() else -1
-    model = pipeline('fill-mask', model='bert-base-uncased', device=device)
+    model = pipeline('fill-mask', model=model_id, device=device)
 
 # Inference is ran for every server call
 # Reference your preloaded global model variable here.

--- a/download.py
+++ b/download.py
@@ -4,10 +4,13 @@
 # In this example: A Huggingface BERT model
 
 from transformers import pipeline
+import os
 
 def download_model():
+    model_id = os.getenv("MODEL_ID")
+    
     # do a dry run of loading the huggingface model, which will download weights
-    pipeline('fill-mask', model='bert-base-uncased')
+    pipeline('fill-mask', model=model_id)
 
 if __name__ == "__main__":
     download_model()


### PR DESCRIPTION
# What is this?

A change to specify the model id in only one place => the dockerfile.

# Why?

To avoid mistakes of changing the model id in one of the current places and therefore loading several models

# How did you test to ensure no regressions?

Built this version of the serverless template on banana and tested inference => everything worked as expected.

# If this is a new feature what is one way you can make this break?
