### PR TITLE
Use COPY instead of ADD in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,20 +8,20 @@ RUN apt-get update && apt-get install -y git
 
 # Install python packages
 RUN pip3 install --upgrade pip
-ADD requirements.txt requirements.txt
+COPY requirements.txt requirements.txt
 RUN pip3 install -r requirements.txt
 
 # We add the banana boilerplate here
-ADD server.py .
+COPY server.py .
 
 # Add your model weight files 
 # (in this case we have a python script)
-ADD download.py .
+COPY download.py .
 RUN python3 download.py
 
 
 # Add your custom app code, init() and inference()
-ADD app.py .
+COPY app.py .
 
 EXPOSE 8000
 


### PR DESCRIPTION
As a template this should make of good defaults and as ADD has some magic behaviors it is now generally recommended to use COPY if you don't need to add tarballs or other advanced features
